### PR TITLE
[ADD] new feature to view queue jobs from program & cycle

### DIFF
--- a/g2p_programs/models/__init__.py
+++ b/g2p_programs/models/__init__.py
@@ -1,5 +1,6 @@
 # Part of OpenG2P. See LICENSE file for full copyright and licensing details.
 
+from . import job_relate_mixin
 from . import constants
 from . import entitlement
 from . import duplicate

--- a/g2p_programs/models/cycle.py
+++ b/g2p_programs/models/cycle.py
@@ -10,7 +10,7 @@ _logger = logging.getLogger(__name__)
 
 
 class G2PCycle(models.Model):
-    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _inherit = ["mail.thread", "mail.activity.mixin", "job.relate.mixin"]
     _name = "g2p.cycle"
     _description = "Cycle"
     _order = "sequence asc"
@@ -311,3 +311,8 @@ class G2PCycle(models.Model):
             "domain": [("entitlement_id", "in", self.entitlement_ids.ids)],
         }
         return action
+
+    def _get_related_job_domain(self):
+        jobs = self.env["queue.job"].search([("model_name", "like", self._name)])
+        related_jobs = jobs.filtered(lambda r: self in r.args[0])
+        return [("id", "in", related_jobs.ids)]

--- a/g2p_programs/models/job_relate_mixin.py
+++ b/g2p_programs/models/job_relate_mixin.py
@@ -1,0 +1,39 @@
+from odoo import models
+
+
+class JobRelateMixin(models.AbstractModel):
+    _name = "job.relate.mixin"
+    _description = "Job Relate Mixin"
+
+    def action_view_related_queue_jobs(self):
+        """
+        Create an action for opening a related queue jobs in form view
+        - Create/ Inherit a model which can be delay when a function is
+        called.
+        - Set inherit to this model
+        - Create a button to call this method
+        - Override function `_get_related_job_domain` to create job domain
+        :return: odoo UI action
+        :rtype: dict
+        :example:
+        class Program(models.Model):
+            _name = "g2p.program"
+            _inherit = ["job.relate.mixin", ...]
+
+            def _get_related_job_domain(self):
+                return [("id", "in", [1, 2, 3])]
+        """
+        self.ensure_one()
+        action = self.env.ref("queue_job.action_queue_job").read()[0]
+        action["domain"] = self._get_related_job_domain()
+
+        return action
+
+    def _get_related_job_domain(self):
+        """
+        Override this function for creating related job queue domain for
+        filtering to action.
+        :return: odoo domain
+        :rtype: list
+        """
+        raise NotImplementedError()

--- a/g2p_programs/models/programs.py
+++ b/g2p_programs/models/programs.py
@@ -9,7 +9,7 @@ _logger = logging.getLogger(__name__)
 
 
 class G2PProgram(models.Model):
-    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _inherit = ["mail.thread", "mail.activity.mixin", "job.relate.mixin"]
     _name = "g2p.program"
     _description = "Program"
     _order = "id desc"
@@ -470,3 +470,8 @@ class G2PProgram(models.Model):
             "domain": [("program_id", "=", self.id)],
         }
         return action
+
+    def _get_related_job_domain(self):
+        jobs = self.env["queue.job"].search([("model_name", "like", self._name)])
+        related_jobs = jobs.filtered(lambda r: self in r.records.program_id)
+        return [("id", "in", related_jobs.ids)]

--- a/g2p_programs/views/cycle_view.xml
+++ b/g2p_programs/views/cycle_view.xml
@@ -152,6 +152,16 @@ Part of OpenG2P. See LICENSE file for full copyright and licensing details.
                                 <span class="o_stat_text">Payments</span>
                             </div>
                         </button>
+                        <button
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-bars"
+                            name="action_view_related_queue_jobs"
+                        >
+                            <div class="o_form_field o_stat_info">
+                                <span class="o_stat_text">Related Job(s)</span>
+                            </div>
+                        </button>
                     </div>
                     <div class="oe_title mb24">
                         <label for="name" string="Cycle:" />

--- a/g2p_programs/views/programs_view.xml
+++ b/g2p_programs/views/programs_view.xml
@@ -132,6 +132,16 @@ Part of OpenG2P. See LICENSE file for full copyright and licensing details.
                                 <span class="o_stat_text">Cycles</span>
                             </div>
                         </button>
+                        <button
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-bars"
+                            name="action_view_related_queue_jobs"
+                        >
+                            <div class="o_form_field o_stat_info">
+                                <span class="o_stat_text">Related Job(s)</span>
+                            </div>
+                        </button>
 
                     </div>
                     <div class="oe_title mb24">


### PR DESCRIPTION
## What this PR does?

Add a new smart button in button box for cycle and program to links them to related queue jobs

![image](https://user-images.githubusercontent.com/31398072/210541889-9038453d-609e-4153-877d-4d90c4e53c1a.png)
![image](https://user-images.githubusercontent.com/31398072/210542088-50d035d0-2db5-4a52-b891-abe8636f3c6a.png)
