### PR TITLE
Fix error in computing total beneficiaries in programs

### DIFF
--- a/g2p_programs/models/managers/entitlement_manager.py
+++ b/g2p_programs/models/managers/entitlement_manager.py
@@ -79,7 +79,9 @@ class BaseEntitlementManager(models.AbstractModel):
 
         jobs = []
         for i in range(0, entitlements_count, 2000):
-            jobs.append(self.delayable()._cancel_entitlements(cycle, i, 2000))
+            jobs.append(
+                self.delayable()._set_pending_validation_entitlements(cycle, i, 2000)
+            )
         main_job = group(*jobs)
         main_job.on_done(
             self.delayable().mark_job_as_done(

--- a/g2p_programs/models/programs.py
+++ b/g2p_programs/models/programs.py
@@ -186,7 +186,7 @@ class G2PProgram(models.Model):
             count = rec.count_beneficiaries(["duplicated"])["value"]
             rec.update({"duplicate_membership_count": count})
 
-    @api.depends("program_membership_ids")
+    @api.depends("program_membership_ids", "program_membership_ids.state")
     def _compute_eligible_beneficiary_count(self):
         for rec in self:
             count = rec.count_beneficiaries(["enrolled"])["value"]
@@ -195,15 +195,15 @@ class G2PProgram(models.Model):
     @api.depends("program_membership_ids")
     def _compute_beneficiary_count(self):
         for rec in self:
-            rec.update({"beneficiaries_count": len(rec.program_membership_ids)})
+            count = rec.count_beneficiaries(None)["value"]
+            rec.update({"beneficiaries_count": count})
 
     @api.depends("cycle_ids")
     def _compute_cycle_count(self):
         for rec in self:
-            cycles_count = 0
-            if rec.cycle_ids:
-                cycles_count = len(rec.cycle_ids)
-            rec.update({"cycles_count": cycles_count})
+            domain = [("program_id", "=", rec.id)]
+            count = self.env["g2p.cycle"].search_count(domain)
+            rec.update({"cycles_count": count})
 
     @api.model
     def get_manager(self, kind):


### PR DESCRIPTION
The change of status of beneficiaries to 'enrolled' (state field in one2many field 'program_membership_ids') did not trigger the '_compute_eligible_beneficiary_count' function. The solution is to add in the `@api.depends` the 'program_membership_ids.state'.