### PR TITLE
Fix error in count functions of non-job queue processed records

### DIFF
--- a/g2p_programs/models/managers/eligibility_manager.py
+++ b/g2p_programs/models/managers/eligibility_manager.py
@@ -43,12 +43,12 @@ class BaseEligibilityManager(models.AbstractModel):
         """
         raise NotImplementedError()
 
-    def verify_cycle_eligibility(self, cycle, program_memberships):
+    def verify_cycle_eligibility(self, cycle, membership):
         """
         This method is used to validate if a beneficiary match the criteria needed to be enrolled in a cycle.
         Args:
             cycle:
-            program_membership:
+            membership:
 
         Returns:
             bool: True if the cycle match the criterias, False otherwise.


### PR DESCRIPTION
This PR fixes the error in beneficiaries, cycles, and entitlements processed without job queue (process less than 200 records) where the update of the count of processed records are not performed.