### PR TITLE
Fix errors in program and cycle beneficiaries enrollment and eligibility verification

### DIFF
--- a/g2p_programs/models/managers/cycle_manager.py
+++ b/g2p_programs/models/managers/cycle_manager.py
@@ -270,9 +270,11 @@ class DefaultCycleManager(models.Model):
         for rec in self:
             rec._ensure_can_edit_cycle(cycle)
 
-            # Get all the draft and enrolled beneficiaries
+            # Get all the draft, enrolled, and not eligible beneficiaries
             if beneficiaries is None:
-                beneficiaries = cycle.get_beneficiaries(["draft", "enrolled"])
+                beneficiaries = cycle.get_beneficiaries(
+                    ["draft", "enrolled", "not_eligible"]
+                )
 
             eligibility_managers = rec.program_id.get_managers(
                 constants.MANAGER_ELIGIBILITY
@@ -447,10 +449,11 @@ class DefaultCycleManager(models.Model):
         self.ensure_one()
         self._ensure_can_edit_cycle(cycle)
         _logger.debug("Adding beneficiaries to the cycle %s", cycle.name)
-        _logger.debug("Beneficiaries: %s", beneficiaries)
+        _logger.debug("Beneficiaries: %s", len(beneficiaries))
 
         # Only add beneficiaries not added yet
         existing_ids = cycle.cycle_membership_ids.mapped("partner_id.id")
+        _logger.debug("Existing IDs: %s", len(existing_ids))
         beneficiaries = list(set(beneficiaries) - set(existing_ids))
         if len(beneficiaries) == 0:
             message = _("No beneficiaries to import.")

--- a/g2p_programs/models/managers/program_manager.py
+++ b/g2p_programs/models/managers/program_manager.py
@@ -141,9 +141,9 @@ class DefaultProgramManager(models.Model):
 
     def enroll_eligible_registrants(self, state=None):
         self.ensure_one()
-        if state is None:
-            states = ["draft"]
-        elif isinstance(state, str):
+        # if state is None:
+        #    states = ["draft"]
+        if isinstance(state, str):
             states = [state]
         else:
             states = state


### PR DESCRIPTION
Errors was discovered when program enrollment and eligibility verification is executed after changing the eligibility criteria to add additional registrants. The error occurs when the enrollment and eligibility verification is done using job queue.

Cycle beneficiaries who are previously set to "not eligible" are not verified for eligibility even if they are already qualified.