### PR TITLE
[FIX] error with default params - mistake with ids and records

### DIFF
--- a/g2p_programs/wizard/multi_entitlement_approval_wizard.py
+++ b/g2p_programs/wizard/multi_entitlement_approval_wizard.py
@@ -39,7 +39,7 @@ class G2PMultiEntitlementApprovalWiz(models.TransientModel):
             )
             if cycle:
                 if cycle.state == "approved":
-                    res["cycle_id"] = cycle_id
+                    res["cycle_id"] = cycle_id.id
                 else:
                     raise ValidationError(
                         _("You can approve only entitlements from approved cycles.")


### PR DESCRIPTION
## What this PR does?

- Default params with relationship fields (m2o, x2m) should get ids instead of records. This PR fix warning raised to Sentry