### PR TITLE
G2p-1294-Removed validation error while approving all entitlements at a time before cycle approval.

### DIFF
--- a/g2p_programs/wizard/multi_entitlement_approval_wizard.py
+++ b/g2p_programs/wizard/multi_entitlement_approval_wizard.py
@@ -1,8 +1,7 @@
 # Part of OpenG2P. See LICENSE file for full copyright and licensing details.
 import logging
 
-from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo import api, fields, models
 
 _logger = logging.getLogger(__name__)
 
@@ -40,10 +39,6 @@ class G2PMultiEntitlementApprovalWiz(models.TransientModel):
             if cycle:
                 if cycle.state == "approved":
                     res["cycle_id"] = cycle_id
-                else:
-                    raise ValidationError(
-                        _("You can approve only entitlements from approved cycles.")
-                    )
             res["entitlement_ids"] = entitlement_ids
 
         return res


### PR DESCRIPTION
G2p-1294 Error message showing proper when user try to delete the approved cycle and allow multi entitlements approval
-Removed validation error while approving all entitlements at a time.