### PR TITLE
Remove offset in search_count as Odoo 17 does not support it anymore

### DIFF
--- a/g2p_programs/models/cycle.py
+++ b/g2p_programs/models/cycle.py
@@ -203,9 +203,7 @@ class G2PCycle(models.Model):
             domain += [("state", "in", state)]
 
         if count:
-            return self.env["g2p.cycle.membership"].search_count(
-                domain, offset=offset, limit=limit
-            )
+            return self.env["g2p.cycle.membership"].search_count(domain, limit=limit)
         return self.env[entitlement_model].search(
             domain, offset=offset, limit=limit, order=order
         )


### PR DESCRIPTION
offset in search_count is not supported in Odoo 17 anymore. This PR removes offset in g2p_program/models/cycle.py.