### PR TITLE
Reflect module name changes in OpenSPP

### DIFF
--- a/g2p_entitlement_differential/__manifest__.py
+++ b/g2p_entitlement_differential/__manifest__.py
@@ -8,7 +8,7 @@
     "website": "https://openg2p.org",
     "license": "Other OSI approved licence",
     "development_status": "Alpha",
-    "depends": ["g2p_entitlement_cash"],
+    "depends": ["spp_entitlement_cash"],
     "data": ["views/entitlement_manager_view.xml"],
     "demo": [],
     "assets": {},

--- a/g2p_entitlement_differential/views/entitlement_manager_view.xml
+++ b/g2p_entitlement_differential/views/entitlement_manager_view.xml
@@ -7,7 +7,7 @@ Part of OpenG2P. See LICENSE file for full copyright and licensing details.
     <record id="view_entitlement_manager_cash_form_diff_inherit" model="ir.ui.view">
         <field name="name">view_entitlement_manager_cash_form_diff_inherit</field>
         <field name="model">g2p.program.entitlement.manager.cash</field>
-        <field name="inherit_id" ref="g2p_entitlement_cash.view_entitlement_manager_cash_form" />
+        <field name="inherit_id" ref="spp_entitlement_cash.view_entitlement_manager_cash_form" />
         <field name="priority">100</field>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='max_amount']" position="after">

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -15,5 +15,5 @@ git+https://github.com/OpenG2P/openg2p-security@17.0-develop#subdirectory=g2p_en
 git+https://github.com/openspp/openspp-modules@17.0#subdirectory=spp_area
 git+https://github.com/openspp/openspp-modules@17.0#subdirectory=spp_service_points
 git+https://github.com/openspp/openspp-modules@17.0#subdirectory=spp_programs
-git+https://github.com/openspp/openspp-modules@17.0#subdirectory=g2p_entitlement_cash
+git+https://github.com/openspp/openspp-modules@17.0#subdirectory=spp_entitlement_cash
 git+https://github.com/openspp/openspp-modules@17.0#subdirectory=spp_entitlement_in_kind


### PR DESCRIPTION
Changed g2p_entitlement_cash -> spp_entitlement_cash to follow the renaming in OpenSPP (PR: https://github.com/OpenSPP/openspp-modules/pull/385 )