### PR TITLE
Fixed cycle approve and entitlement's auto approve

### DIFF
--- a/g2p_programs/models/cycle.py
+++ b/g2p_programs/models/cycle.py
@@ -285,13 +285,6 @@ class G2PCycle(models.Model):
             entitlement_manager = rec.program_id.get_manager(constants.MANAGER_ENTITLEMENT)
             if not entitlement_manager:
                 raise UserError(_("No Entitlement Manager defined."))
-            rec.write(
-                {
-                    "approved_date": fields.Datetime.now(),
-                    "approved_by": self.env.user.id,
-                    "state": self.STATE_APPROVED,
-                }
-            )
             return cycle_manager.approve_cycle(
                 rec,
                 auto_approve=cycle_manager.auto_approve_entitlements,

--- a/g2p_programs/models/managers/cycle_manager.py
+++ b/g2p_programs/models/managers/cycle_manager.py
@@ -110,7 +110,13 @@ class BaseCycleManager(models.AbstractModel):
         """
         # Check if user is allowed to approve the cycle
         if cycle.state == "to_approve":
-            cycle.update({"state": "approved"})
+            cycle.update(
+                {
+                    "approved_date": fields.Datetime.now(),
+                    "approved_by": self.env.user.id,
+                    "state": cycle.STATE_APPROVED,
+                }
+            )
             # Running on_state_change because it is not triggered automatically with rec.update above
             self.on_state_change(cycle)
         else:


### PR DESCRIPTION
## Why is this change needed?

There are two errors that needs to fix
- In cycle, upon clicking the `Approve` button, there an error notification that displays `Only 'to approve' cycles can be approved.` but the cycle is still approved.
- Auto approve of entitlement is not working.

## How was the change implemented?

The cause of error is due to the wrong placement of updating the state, approved_date, and approved_by of the cycle, To fix this, I changed the code placement to cycle manager

## How to test manually...

- Install g2p_programs module
- Go to Programs and click `Create Program`
- in the `Configure the Cycle Manager` Tab, check the `Auto-approve Entitlements`
- in the same tab, add an Approver Group, Administrator will do.
- Click Next
- Click the `Yes` radio button then click `Create.
- in the Program page, click the `Create New Cycle` button. A new cycle will be added in the `Cycles` tab.
- Enter the cycle by clicking the green button on its left side
- Click `Prepare Entitlement` button
- Click `To Approve` button
- Click `Approve` button

- After click `Approve` button, check if there is no error notification that says `Only 'to approve' cycles can be approved.`
- Check also if the Cycle is in `Approved state`.

- Click the `Entitlements` button in the top-center part.
- Check if the Entitlement's state are `Approved`.