### PR TITLE
fix: use sudo for config parameter access

### DIFF
--- a/g2p_openid_vci_programs/tests/test_vci_programs.py
+++ b/g2p_openid_vci_programs/tests/test_vci_programs.py
@@ -16,7 +16,7 @@ from odoo.tools import misc
 class TestVCIIssuerProgram(TransactionCase):
     def setUp(self):
         super().setUp()
-        self.env["ir.config_parameter"].set_param("web.base.url", "http://openg2p.local")
+        self.env["ir.config_parameter"].sudo().set_param("web.base.url", "http://openg2p.local")
         self.id_type = self.env["g2p.id.type"].create(
             {
                 "name": "NATIONAL ID",


### PR DESCRIPTION
**Fixes access issue by using sudo() when reading from ir.config_parameter to ensure compatibility for non-admin users.**